### PR TITLE
fix(vibranium::compiler): treat stderr as error output

### DIFF
--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -141,3 +141,21 @@ fn it_should_fail_when_given_compiler_option_is_not_supported_and_no_compiler_op
   tmp_dir.close()?;
   Ok(())
 }
+
+#[test]
+fn it_should_fail_when_compiler_program_fails() -> Result<(), Box<std::error::Error>> {
+
+  let (tmp_dir, project_path) = setup_vibranium_project()?;
+
+  let mut cmd = Command::main_binary()?;
+
+  cmd.arg("compile")
+      .arg("--path")
+      .arg(&project_path);
+
+  cmd.assert()
+      .failure();
+
+  tmp_dir.close()?;
+  Ok(())
+}

--- a/src/compiler/error.rs
+++ b/src/compiler/error.rs
@@ -11,6 +11,7 @@ pub enum CompilerError {
   VibraniumDirectoryNotFound(project_generator::error::ProjectGenerationError),
   InvalidConfig(config::error::ConfigError),
   UnsupportedStrategy,
+  Other(String),
 }
 
 impl Error for CompilerError {
@@ -25,6 +26,7 @@ impl Error for CompilerError {
       CompilerError::VibraniumDirectoryNotFound(error) => error.description(),
       CompilerError::InvalidConfig(error) => error.description(),
       CompilerError::UnsupportedStrategy => "Couldn't compile project without `CompilerConfig::compiler_options`. No built-in support for requested compiler.",
+      CompilerError::Other(message) => message,
     }
   }
 
@@ -34,6 +36,7 @@ impl Error for CompilerError {
       CompilerError::VibraniumDirectoryNotFound(error) => Some(error),
       CompilerError::InvalidConfig(error) => Some(error),
       CompilerError::UnsupportedStrategy => None,
+      CompilerError::Other(_message) => None,
     }
   }
 }
@@ -45,6 +48,7 @@ impl fmt::Display for CompilerError {
       CompilerError::VibraniumDirectoryNotFound(error) => write!(f, "{}", error),
       CompilerError::InvalidConfig(error) => write!(f, "{}", error),
       CompilerError::UnsupportedStrategy => write!(f, "{}", self.description()),
+      CompilerError::Other(_message) => write!(f, "{}", self.description()),
     }
   }
 }

--- a/src/compiler/strategy/default.rs
+++ b/src/compiler/strategy/default.rs
@@ -1,5 +1,5 @@
 use super::Strategy;
-use std::process::{Command, Child};
+use std::process::{Command, Child, Stdio};
 
 pub struct DefaultStrategy<'a> {
   pub compiler_bin: &'a str,
@@ -17,6 +17,10 @@ impl<'a> DefaultStrategy<'a> {
 
 impl<'a> Strategy for DefaultStrategy<'a> {
   fn execute(&self) -> Result<Child, std::io::Error> {
-    Command::new(&self.compiler_bin).args(&self.compiler_options).spawn()
+    Command::new(&self.compiler_bin)
+      .args(&self.compiler_options)
+      .stdout(Stdio::piped())
+      .stderr(Stdio::piped())
+      .spawn()
   }
 }

--- a/src/compiler/strategy/solc.rs
+++ b/src/compiler/strategy/solc.rs
@@ -1,5 +1,5 @@
 use super::Strategy;
-use std::process::{Command, Child};
+use std::process::{Command, Child, Stdio};
 use std::path::{PathBuf};
 use glob::glob;
 
@@ -47,6 +47,8 @@ impl<'a> Strategy for SolcStrategy<'a> {
     Command::new(SOLC_COMPILER_BINARY)
       .args(args)
       .args(&self.config.compiler_options)
+      .stdout(Stdio::piped())
+      .stderr(Stdio::piped())
       .spawn()
   }
 }


### PR DESCRIPTION
Prior to this commit, when running

```
$ vibranium compile
```

And the underlying compiler would fail, Vibranium would still treat the
result as successful. This was because we didn't capture `Stdio` from
the underlying process.

With this commit we're introducing `compiler::error::CompilerError::Other(String)`,
capture `stdout` and `stderr from the underlying `Child` process and emit and
error with `stderr`.

At the same time we're moving some output messages around to reduce redundancy.