### PR TITLE
feat: improve compiler option configuration with vibranium.toml

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -16,9 +16,15 @@ impl Error for CliError {
       CliError::CompilationError(error) => {
         match error {
           CompilerError::UnsupportedStrategy => r###"No built-in support for requested compiler.
-To use this compiler, specify ARGS in compile command. E.g:
+To use this compiler, please specify necessary OPTIONS in compile command. E.g:
 
-  vibranium compile --compiler solcjs -- <ARGS>..."###,
+  vibranium compile --compiler solcjs -- <OPTIONS>...
+
+OPTIONS can also be specified in the project's vibranium.toml file:
+
+  [compiler]
+    options = ["--option1", "--option2"]
+"###,
           _ => error.description()
 
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,7 +16,6 @@ use vibranium::compiler::CompilerConfig;
 mod error;
 
 const DEFAULT_NODE_CLIENT: &str = "parity";
-const DEFAULT_COMPILER: &str = "solc";
 
 type Error = Box<std::error::Error>;
 
@@ -125,18 +124,14 @@ fn run() -> Result<(), Error> {
   if let("compile", Some(cmd)) = matches.subcommand() {
     println!("Compiling Vibranium project...");
     let path = pathbuf_from_or_current_dir(cmd.value_of("path"))?;
-    let compiler_bin = cmd.value_of("compiler").unwrap_or(DEFAULT_COMPILER);
-
-    let mut compiler_options = vec![];
-
-    if let Some(options) = cmd.values_of("compiler-opts") {
-      compiler_options = options.collect();
-    }
-
     let vibranium = Vibranium::new(path);
 
+    let compiler_options = cmd.values_of("compiler-opts").map(|options| {
+      options.map(|val| val.to_string()).collect()
+    });
+
     let config = CompilerConfig {
-      compiler: compiler_bin.to_string(),
+      compiler: cmd.value_of("compiler").map(|cmd| cmd.to_string()),
       compiler_options,
     };
 

--- a/src/compiler/strategy/default.rs
+++ b/src/compiler/strategy/default.rs
@@ -1,13 +1,13 @@
 use super::Strategy;
 use std::process::{Command, Child, Stdio};
 
-pub struct DefaultStrategy<'a> {
-  pub compiler_bin: &'a str,
-  pub compiler_options: Vec<&'a str>,
+pub struct DefaultStrategy {
+  pub compiler_bin: String,
+  pub compiler_options: Vec<String>,
 }
 
-impl<'a> DefaultStrategy<'a> {
-  pub fn new(compiler_bin: &'a str, compiler_options: Vec<&'a str>) -> DefaultStrategy<'a> {
+impl DefaultStrategy {
+  pub fn new(compiler_bin: String, compiler_options: Vec<String>) -> DefaultStrategy {
     DefaultStrategy {
       compiler_bin,
       compiler_options
@@ -15,7 +15,7 @@ impl<'a> DefaultStrategy<'a> {
   }
 }
 
-impl<'a> Strategy for DefaultStrategy<'a> {
+impl Strategy for DefaultStrategy {
   fn execute(&self) -> Result<Child, std::io::Error> {
     Command::new(&self.compiler_bin)
       .args(&self.compiler_options)

--- a/src/compiler/strategy/mod.rs
+++ b/src/compiler/strategy/mod.rs
@@ -9,11 +9,11 @@ pub trait Strategy {
   fn execute(&self) -> Result<Child, std::io::Error>;
 }
 
-pub struct StrategyConfig<'a> {
+pub struct StrategyConfig {
   pub input_path: PathBuf,
   pub output_path: PathBuf,
   pub smart_contract_sources: Vec<String>,
-  pub compiler_options: Vec<&'a str>,
+  pub compiler_options: Option<Vec<String>>,
 }
 
 pub struct CompilerStrategy<'a> {

--- a/src/compiler/strategy/solcjs.rs
+++ b/src/compiler/strategy/solcjs.rs
@@ -4,11 +4,11 @@ use glob::glob;
 
 pub const SOLC_JS_COMPILER_BINARY: &str = "solcjs";
 
-pub struct SolcJsStrategy<'a> {
-  config: StrategyConfig<'a>
+pub struct SolcJsStrategy {
+  config: StrategyConfig
 }
 
-impl<'a> SolcJsStrategy<'a> {
+impl SolcJsStrategy {
   pub fn new(config: StrategyConfig) -> SolcJsStrategy {
     SolcJsStrategy {
       config
@@ -16,26 +16,30 @@ impl<'a> SolcJsStrategy<'a> {
   }
 }
 
-impl<'a> Strategy for SolcJsStrategy<'a> {
+impl Strategy for SolcJsStrategy {
 
   fn execute(&self) -> Result<Child, std::io::Error> {
-    let mut args: Vec<String> = vec![
-      "--abi".to_string(),
-      "-o".to_string(),
-      self.config.output_path.to_string_lossy().to_string()
-    ];
+    let mut compiler_options = vec!["--abi".to_string()];
+
+    if let Some(options) = &self.config.compiler_options {
+      compiler_options.append(&mut options.clone());
+      compiler_options.sort();
+      compiler_options.dedup();
+    }
+
+    compiler_options.push("-o".to_string());
+    compiler_options.push(self.config.output_path.to_string_lossy().to_string());
 
     for pattern in &self.config.smart_contract_sources {
       let mut full_pattern = self.config.input_path.clone();
       full_pattern.push(&pattern);
       for entry in glob(&full_pattern.to_str().unwrap()).unwrap().filter_map(Result::ok) {
-        args.push(entry.to_string_lossy().to_string());
+        compiler_options.push(entry.to_string_lossy().to_string());
       }
     }
 
     Command::new(SOLC_JS_COMPILER_BINARY)
-      .args(args)
-      .args(&self.config.compiler_options)
+      .args(compiler_options)
       .stdout(Stdio::piped())
       .stderr(Stdio::piped())
       .spawn()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,13 @@ pub const VIBRANIUM_CONFIG_FILE: &str = "vibranium.toml";
 pub struct ProjectConfig {
   pub artifacts_dir: String,
   pub smart_contract_sources: Vec<String>,
+  pub compiler: Option<ProjectCompilerConfig>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProjectCompilerConfig {
+  pub cmd: Option<String>,
+  pub options: Option<Vec<String>>
 }
 
 #[derive(Default, Debug)]

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -35,7 +35,8 @@ impl<'a> ProjectGenerator<'a> {
 
       let config = config::ProjectConfig {
         artifacts_dir: DEFAULT_ARTIFACTS_DIRECTORY.to_string(),
-        smart_contract_sources: vec![DEFAULT_CONTRACTS_DIRECTORY.to_string() + "/*.sol"]
+        smart_contract_sources: vec![DEFAULT_CONTRACTS_DIRECTORY.to_string() + "/*.sol"],
+        compiler: None,
       };
 
       let config_toml = toml::to_string(&config).map_err(error::ProjectGenerationError::Serialization)?;


### PR DESCRIPTION
This enables users to specify compiler specific options in the vibranium.toml
configuration file. Possible options are `compiler.cmd` and `compiler.options`.

Example:

```
[compiler]
cmd = "solcjs"
options = ["--abi", "--optimize"]
```

This configuration overrules Vibranium's default configuration (e.g. Vibranium
uses `solc` by default). `compiler.options` are "merged" with default options
specified in the compiler.

Given a configuration like above, it's still possible to override these on a
command basis. E.g:

```
$ vibranium compile --compiler solc -- --standard-json
```

Will dismiss `compiler.cmd` and `compiler.options` in vibranium.toml.

It's also possible to only specify one of these options. For example having:

```
[compiler]
cmd = "solcjs"
```

And running

```
$ vibranium compile
```

Will just work, due to Vibranium's built-in strategy for `solcjs`.

The same way it's possible to just supply compiler options and set the compiler
program on the fly:

```
[compiler]
options = ["--abi"]
```
```
$ vibranium compile --compiler solcjs
```

This will still use the options defined in vibranium.toml. In fact, this could
be combined with a compiler that Vibranium doesn't have a compiler strategy for:

```
$ vibranium compile --compiler unsupported
```

Which would be the equivalent to running:

```
$ vibranium compile --compiler unsupported -- --abi
```