### PR TITLE
feat(vibranium::config): introduce command to set config options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 toml = "0.4.10"
+toml-query = "0.8.0"
 serde = "1.0"
 serde_derive = "1.0"
 glob = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 clap = "2.32.0"
+toml = "0.4.10"
 vibranium = { path = "../" }
 
 [dev-dependencies]

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -1,4 +1,5 @@
 extern crate vibranium;
+extern crate toml;
 
 use std::error::Error;
 use std::fmt;
@@ -8,6 +9,7 @@ use vibranium::compiler::error::CompilerError;
 #[derive(Debug)]
 pub enum CliError {
   CompilationError(CompilerError),
+  ConfigurationSetError(toml::ser::Error),
 }
 
 impl Error for CliError {
@@ -28,13 +30,15 @@ OPTIONS can also be specified in the project's vibranium.toml file:
           _ => error.description()
 
         }
-      } 
+      },
+      CliError::ConfigurationSetError(error) => error.description(),
     }
   }
 
   fn cause(&self) -> Option<&Error> {
     match self {
       CliError::CompilationError(error) => Some(error),
+      CliError::ConfigurationSetError(error) => Some(error),
     }
   }
 }
@@ -43,6 +47,7 @@ impl fmt::Display for CliError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       CliError::CompilationError(_error) => write!(f, "{}", self.description()),
+      CliError::ConfigurationSetError(error) => write!(f, "Couldn't set configuration: {}", error),
     }
   }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -30,7 +30,7 @@ impl<'a> Compiler<'a> {
 
   pub fn compile(&self, config: CompilerConfig) -> Result<Child, error::CompilerError> {
     let project_config = self.config.read().map_err(error::CompilerError::InvalidConfig)?;
-    let artifacts_dir = self.config.project_path.join(&project_config.artifacts_dir);
+    let artifacts_dir = self.config.project_path.join(&project_config.sources.artifacts);
 
     let compiler = config.compiler.unwrap_or_else(|| {
       match &project_config.compiler {
@@ -52,7 +52,7 @@ impl<'a> Compiler<'a> {
     let strategy_config = StrategyConfig {
       input_path: PathBuf::from(&self.config.project_path),
       output_path: artifacts_dir,
-      smart_contract_sources: project_config.smart_contract_sources,
+      smart_contract_sources: project_config.sources.smart_contracts,
       compiler_options: compiler_options.clone()
     };
 

--- a/src/config/error.rs
+++ b/src/config/error.rs
@@ -1,4 +1,5 @@
 extern crate toml;
+extern crate toml_query;
 
 use std::error::Error;
 use std::fmt;
@@ -8,7 +9,9 @@ use std::io;
 pub enum ConfigError {
   Serialization(toml::ser::Error),
   Deserialization(toml::de::Error),
+  Query(toml_query::error::Error),
   Io(io::Error),
+  Other(String),
 }
 
 impl Error for ConfigError {
@@ -16,7 +19,9 @@ impl Error for ConfigError {
     match self {
       ConfigError::Serialization(error) => error.description(),
       ConfigError::Deserialization(error) => error.description(),
+      ConfigError::Query(_error) => "",
       ConfigError::Io(error) => error.description(),
+      ConfigError::Other(message) => message,
     }
   }
 
@@ -24,7 +29,9 @@ impl Error for ConfigError {
     match self {
       ConfigError::Serialization(error) => Some(error),
       ConfigError::Deserialization(error) => Some(error),
+      ConfigError::Query(_error) => None,
       ConfigError::Io(error) => Some(error),
+      ConfigError::Other(_message) => None,
     }
   }
 }
@@ -34,7 +41,9 @@ impl fmt::Display for ConfigError {
     match self {
       ConfigError::Serialization(error) => write!(f, "Couldn't serialize vibranium config: {}", error),
       ConfigError::Deserialization(error) => write!(f, "Couldn't deserialize vibranium config: {}", error),
+      ConfigError::Query(error) => write!(f, "Couldn't query configuration: {}", error),
       ConfigError::Io(error) => write!(f, "Couldn't access configuration file: {}", error),
+      ConfigError::Other(_message) => write!(f, "{}", self.description()),
     }
   }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,14 +1,19 @@
+extern crate toml;
+extern crate toml_query;
 pub mod error;
 
-use std::fs;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
 use std::path::PathBuf;
+use toml_query::set::TomlValueSetExt;
+use toml_query::insert::TomlValueInsertExt;
+use toml_query::error::Error::IdentifierNotFoundInDocument;
 
 pub const VIBRANIUM_CONFIG_FILE: &str = "vibranium.toml";
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProjectConfig {
-  pub artifacts_dir: String,
-  pub smart_contract_sources: Vec<String>,
+  pub sources: ProjectSourcesConfig,
   pub compiler: Option<ProjectCompilerConfig>,
 }
 
@@ -16,6 +21,12 @@ pub struct ProjectConfig {
 pub struct ProjectCompilerConfig {
   pub cmd: Option<String>,
   pub options: Option<Vec<String>>
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ProjectSourcesConfig {
+  pub artifacts: String,
+  pub smart_contracts: Vec<String>,
 }
 
 #[derive(Default, Debug)]
@@ -38,6 +49,31 @@ impl Config {
 
   pub fn read(&self) -> Result<ProjectConfig, error::ConfigError> {
     toml::from_str(&fs::read_to_string(&self.config_file).map_err(error::ConfigError::Io)?).map_err(error::ConfigError::Deserialization)
+  }
+
+  pub fn write(&self, option: String, value: toml::Value) -> Result<(), error::ConfigError> {
+    let mut config = toml::Value::try_from(self.read()?).map_err(error::ConfigError::Serialization)?;
+
+    if let Err(err) = config.set(&option, value.clone()) {
+      match err {
+        IdentifierNotFoundInDocument(_message) => {
+          config.insert(&option, value.clone()).map_err(error::ConfigError::Query)?;
+        },
+        _ => Err(error::ConfigError::Query(err))?
+      }
+    }
+
+    config.try_into::<ProjectConfig>()
+      .map_err(error::ConfigError::Deserialization)
+      .and_then(|cfg| {
+        let config_toml = toml::to_string(&cfg).map_err(error::ConfigError::Serialization)?;
+        let mut config_file = fs::File::create(&self.config_file)
+          .map_err(error::ConfigError::Io)?;
+
+        config_file.write_all(config_toml.as_bytes()).map_err(error::ConfigError::Io)
+      })?;
+
+    Ok(())
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ extern crate glob;
 #[derive(Debug)]
 pub struct Vibranium {
   project_path: PathBuf,
-  config: config::Config,
+  pub config: config::Config,
 }
 
 impl Vibranium {
@@ -41,6 +41,14 @@ impl Vibranium {
     generator
       .reset_project(&self.project_path)
       .and_then(|_| generator.generate_project(&self.project_path))
+  }
+
+  pub fn set_config(&self, option: String, value: toml::Value) -> Result<(), config::error::ConfigError> {
+    let generator = project_generator::ProjectGenerator::new(&self.config);
+    generator
+      .check_vibranium_dir_exists()
+      .map_err(|error| config::error::ConfigError::Other(error.to_string()))
+      .and_then(|_| self.config.write(option, value))
   }
 
   pub fn compile(&self, config: compiler::CompilerConfig) -> Result<Output, compiler::error::CompilerError> {

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -34,8 +34,10 @@ impl<'a> ProjectGenerator<'a> {
       directories_to_create.push(DEFAULT_ARTIFACTS_DIRECTORY.to_string());
 
       let config = config::ProjectConfig {
-        artifacts_dir: DEFAULT_ARTIFACTS_DIRECTORY.to_string(),
-        smart_contract_sources: vec![DEFAULT_CONTRACTS_DIRECTORY.to_string() + "/*.sol"],
+        sources: config::ProjectSourcesConfig {
+          artifacts: DEFAULT_ARTIFACTS_DIRECTORY.to_string(),
+          smart_contracts: vec![DEFAULT_CONTRACTS_DIRECTORY.to_string() + "/*.sol"],
+        },
         compiler: None,
       };
 
@@ -44,7 +46,7 @@ impl<'a> ProjectGenerator<'a> {
       config_file.write_all(config_toml.as_bytes()).map_err(error::ProjectGenerationError::Io)?;
     } else {
       let existing_config = self.config.read().map_err(error::ProjectGenerationError::InvalidConfig)?;
-      directories_to_create.push(existing_config.artifacts_dir);
+      directories_to_create.push(existing_config.sources.artifacts);
     }
 
     for directory in directories_to_create {
@@ -62,7 +64,7 @@ impl<'a> ProjectGenerator<'a> {
 
     if self.config.exists() {
       let existing_config = self.config.read().map_err(error::ProjectGenerationError::InvalidConfig)?;
-      let _ = fs::remove_dir_all(project_path.join(existing_config.artifacts_dir));
+      let _ = fs::remove_dir_all(project_path.join(existing_config.sources.artifacts));
     }
 
     let _ = fs::remove_dir_all(vibranium_project_directory);


### PR DESCRIPTION
This adds a new CLI command to set configuration values that follow the `ProjectConfig` type.
Config values can be set like this:

```
$ vibranium config CONFIG_OPTION VALUE [OPTIONS]
```

For example, the following command updates the `artifacts` directory path:

```
$ vibranium config sources.artifacts 'some/folder'
```

This will write the following TOML into the project's vibranium.toml file:

```
[sources]
artifacts = "some/folder"
```

The command ignores fields that don't exist in `ProjectConfig`. The following command
has no effect:

```
$ vibranium config unknown.option foo
```

Some options contain multiple values using arrays. Multiple values per option can be specified
as single string argument with array syntax:

```
$ vibranium config compiler.options "[--optimize, --optimize-runs=50]"
```

Which will generate:

```
[compiler]
options = ["--optimize", "--optimize-runs=50"]
```
Like any other Vibranium command, this command comes with a `--path` option as well, to specify
the location of a Vibranium project.

BREAKING CHANGE:

`ProjectConfig` has changed. `artifacts_dir` and `smart_contract_sources` don't exist anymore and
have been replaces by `sources.artifacts` and `sources.smart_contracts`:

```
[sources]
artifacts = "artifacts"
smart_contracts = ["contracts/*.sol"]
```

Closes #12