### PR TITLE
refactor(vibranium::compiler): rename Strategy trait to Compile trait

### DIFF
--- a/src/compiler/strategy/default.rs
+++ b/src/compiler/strategy/default.rs
@@ -1,4 +1,4 @@
-use super::Strategy;
+use super::Compile;
 use std::process::{Command, Child, Stdio};
 
 pub struct DefaultStrategy {
@@ -15,8 +15,8 @@ impl DefaultStrategy {
   }
 }
 
-impl Strategy for DefaultStrategy {
-  fn execute(&self) -> Result<Child, std::io::Error> {
+impl Compile for DefaultStrategy {
+  fn compile(&self) -> Result<Child, std::io::Error> {
     info!("Compiling project using command: {} {}", &self.compiler_bin, self.compiler_options.join(" "));
     Command::new(&self.compiler_bin)
       .args(&self.compiler_options)

--- a/src/compiler/strategy/mod.rs
+++ b/src/compiler/strategy/mod.rs
@@ -5,8 +5,8 @@ pub mod solc;
 use std::path::{PathBuf};
 use std::process::{Child};
 
-pub trait Strategy {
-  fn execute(&self) -> Result<Child, std::io::Error>;
+pub trait Compile {
+  fn compile(&self) -> Result<Child, std::io::Error>;
 }
 
 pub struct StrategyConfig {
@@ -17,17 +17,17 @@ pub struct StrategyConfig {
 }
 
 pub struct CompilerStrategy<'a> {
-  strategy: Box<Strategy + 'a>,
+  strategy: Box<Compile + 'a>,
 }
 
 impl<'a> CompilerStrategy<'a> {
-  pub fn new(strategy: Box<Strategy + 'a>) -> CompilerStrategy {
+  pub fn new(strategy: Box<Compile + 'a>) -> CompilerStrategy {
     CompilerStrategy {
       strategy
     }
   }
 
   pub fn execute(&self) -> Result<Child, std::io::Error> {
-    self.strategy.execute()
+    self.strategy.compile()
   }
 }

--- a/src/compiler/strategy/solc.rs
+++ b/src/compiler/strategy/solc.rs
@@ -1,4 +1,4 @@
-use super::{Strategy, StrategyConfig};
+use super::{Compile, StrategyConfig};
 use std::process::{Command, Child, Stdio};
 use glob::glob;
 
@@ -16,8 +16,8 @@ impl SolcStrategy {
   }
 }
 
-impl Strategy for SolcStrategy {
-  fn execute(&self) -> Result<Child, std::io::Error> {
+impl Compile for SolcStrategy {
+  fn compile(&self) -> Result<Child, std::io::Error> {
 
     let mut compiler_options = vec![
       "--abi".to_string(),

--- a/src/compiler/strategy/solcjs.rs
+++ b/src/compiler/strategy/solcjs.rs
@@ -1,4 +1,4 @@
-use super::{Strategy, StrategyConfig};
+use super::{Compile, StrategyConfig};
 use std::process::{Command, Child, Stdio};
 use glob::glob;
 
@@ -16,9 +16,9 @@ impl SolcJsStrategy {
   }
 }
 
-impl Strategy for SolcJsStrategy {
+impl Compile for SolcJsStrategy {
 
-  fn execute(&self) -> Result<Child, std::io::Error> {
+  fn compile(&self) -> Result<Child, std::io::Error> {
     let mut compiler_options = vec!["--abi".to_string()];
 
     if let Some(options) = &self.config.compiler_options {


### PR DESCRIPTION
`Strategy` is too ambiguous and makes it hard to come up with names for other
strategy traits within Vibranium.