### PR TITLE
feat: introduce blockchain section in project config

### DIFF
--- a/src/blockchain/error.rs
+++ b/src/blockchain/error.rs
@@ -1,31 +1,35 @@
 use std::io;
 use std::fmt;
-use std::error;
+use std::error::Error;
 
 #[derive(Debug)]
 pub enum NodeError {
   Io(io::Error),
+  UnsupportedClient,
+  Other(String),
+}
+
+impl Error for NodeError {
+  fn description(&self) -> &str {
+    match self {
+      NodeError::Io(ref err) => err.description(),
+      NodeError::UnsupportedClient => "No built-in support for request blockchain client. Please specify NodeConfig.client_options",
+      NodeError::Other(message) => message,
+    }
+  }
 }
 
 impl fmt::Display for NodeError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    match *self {
+    match self {
       NodeError::Io(ref err) => {
         match err.kind() {
           io::ErrorKind::NotFound => write!(f, "Couldn't find executable for node client"),
           _ => write!(f, "{}", err),
         }
-      }
+      },
+      NodeError::UnsupportedClient => write!(f, "{}", self.description()),
+      NodeError::Other(_message) => write!(f, "{}", self.description()),
     }
   }
 }
-
-impl error::Error for NodeError {
-  fn description(&self) -> &str {
-    match *self {
-      NodeError::Io(ref err) => err.description(),
-    }
-  }
-}
-
-

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -1,29 +1,51 @@
 extern crate log;
 
 use std::process::{Command, Child};
+use crate::config;
 
 pub mod error;
+pub mod support;
 
-pub struct NodeConfig<'a> {
-  pub client: &'a str,
-  pub client_options: &'a Vec<&'a str>,
+pub struct NodeConfig {
+  pub client: Option<String>,
+  pub client_options: Option<Vec<String>>,
 }
 
 pub struct Node<'a> {
-  config: NodeConfig<'a>,
+  config: &'a config::Config
 }
 
 impl<'a> Node<'a> {
-  pub fn new(config: NodeConfig) -> Node {
+  pub fn new(config: &config::Config) -> Node {
     Node {
       config,
     }
   }
 
-  pub fn start(&self) -> Result<Child, error::NodeError> {
-    info!("Starting node with command: {} {}", &self.config.client, self.config.client_options.join(" "));
-    Command::new(self.config.client)
-            .args(self.config.client_options)
+  pub fn start(&self, config: NodeConfig) -> Result<Child, error::NodeError> {
+    let project_config = self.config.read().map_err(|error| error::NodeError::Other(error.to_string()))?;
+
+    let client = config.client.unwrap_or_else(|| {
+      match &project_config.blockchain {
+        Some(config) => config.cmd.clone().unwrap_or_else(|| support::SupportedBlockchainClients::Parity.to_string()),
+        None => support::SupportedBlockchainClients::Parity.to_string(),
+      }
+    });
+
+    let client_options: Vec<String> = match &config.client_options {
+      Some(options) => options.to_vec(),
+      None => {
+        match project_config.blockchain {
+          Some(config) => config.options.unwrap_or(vec![]),
+          None => vec![]
+        }
+      }
+    };
+
+    info!("Starting node with command: {} {}", &client, client_options.join(" "));
+
+    Command::new(client)
+            .args(client_options)
             .spawn()
             .map_err(error::NodeError::Io)
   }

--- a/src/blockchain/support.rs
+++ b/src/blockchain/support.rs
@@ -1,0 +1,27 @@
+use super::error;
+use std::str::FromStr;
+use std::string::ToString;
+
+const DEFAULT_NODE_CLIENT: &str = "parity";
+
+pub enum SupportedBlockchainClients {
+  Parity,
+}
+
+impl FromStr for SupportedBlockchainClients {
+  type Err = error::NodeError;
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      DEFAULT_NODE_CLIENT => Ok(SupportedBlockchainClients::Parity),
+      _ => Err(error::NodeError::UnsupportedClient),
+    }
+  }
+}
+
+impl ToString for SupportedBlockchainClients {
+  fn to_string(&self) -> String {
+    match self {
+      SupportedBlockchainClients::Parity => DEFAULT_NODE_CLIENT.to_string(),
+    }
+  }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -14,11 +14,12 @@ pub const VIBRANIUM_CONFIG_FILE: &str = "vibranium.toml";
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ProjectConfig {
   pub sources: ProjectSourcesConfig,
-  pub compiler: Option<ProjectCompilerConfig>,
+  pub compiler: Option<ProjectCmdExecutionConfig>,
+  pub blockchain: Option<ProjectCmdExecutionConfig>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ProjectCompilerConfig {
+pub struct ProjectCmdExecutionConfig {
   pub cmd: Option<String>,
   pub options: Option<Vec<String>>
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,16 @@ impl Vibranium {
   }
 
   pub fn start_node(&self, config: blockchain::NodeConfig) -> Result<ExitStatus, blockchain::error::NodeError> {
-    let node = blockchain::Node::new(config);
-    node.start()
-        .map(|mut process| process.wait().map_err(blockchain::error::NodeError::Io))
-        .and_then(|status| status)
+    let generator = project_generator::ProjectGenerator::new(&self.config);
+    generator
+      .check_vibranium_dir_exists()
+      .map_err(|error| blockchain::error::NodeError::Other(error.to_string()))
+      .and_then(|_| {
+        let node = blockchain::Node::new(&self.config);
+        node.start(config)
+          .map(|mut process| process.wait().map_err(blockchain::error::NodeError::Io))
+          .and_then(|status| status)
+      })
   }
 
   pub fn init_project(&self) -> Result<(), project_generator::error::ProjectGenerationError> {

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -40,6 +40,7 @@ impl<'a> ProjectGenerator<'a> {
           smart_contracts: vec![DEFAULT_CONTRACTS_DIRECTORY.to_string() + "/*.sol"],
         },
         compiler: None,
+        blockchain: None,
       };
 
       info!("Creating: {}", &self.config.config_file.to_str().unwrap());


### PR DESCRIPTION
This enables users to specify the blockchain command and command options
as part of their project configuration:

```
[blockchain]
cmd = "parity"
options = ["--config", "dev"]
```

Both of them are optional and Vibranium will honor them as part of the
`node` command.