### PR TITLE
feat(vibranium::cli): introduce --restore-config option in reset command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,7 @@ use clap::{App, SubCommand, Arg};
 use vibranium::Vibranium;
 use vibranium::blockchain::NodeConfig;
 use vibranium::compiler::CompilerConfig;
+use vibranium::project_generator::ResetOptions;
 
 mod error;
 
@@ -79,6 +80,10 @@ fn run() -> Result<(), Error> {
                       .value_name("PATH")
                       .help("Specifies path to Vibranium project to reset")
                       .takes_value(true))
+                    .arg(Arg::with_name("restore-config")
+                      .short("rc")
+                      .long("restore-config")
+                      .help("Flag to specify whether the project's vibranium.toml file should be reset to Vibranium's defaults"))
                     .arg(Arg::with_name("verbose")
                       .short("v")
                       .long("verbose")
@@ -172,7 +177,10 @@ fn run() -> Result<(), Error> {
       println!("Resetting Vibranium project...");
       let path = pathbuf_from_or_current_dir(cmd.value_of("path"))?;
       let vibranium = Vibranium::new(path);
-      vibranium.reset_project().and_then(|_| {
+
+      vibranium.reset_project(ResetOptions {
+        restore_config: cmd.is_present("restore-config")
+      }).and_then(|_| {
         println!("Done.");
         Ok(())
       })?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,10 +44,10 @@ impl Vibranium {
     generator.generate_project(&self.project_path)
   }
 
-  pub fn reset_project(&self) -> Result<(), project_generator::error::ProjectGenerationError> {
+  pub fn reset_project(&self, reset_options: project_generator::ResetOptions) -> Result<(), project_generator::error::ProjectGenerationError> {
     let generator = project_generator::ProjectGenerator::new(&self.config);
     generator
-      .reset_project(&self.project_path)
+      .reset_project(&self.project_path, reset_options)
       .and_then(|_| generator.generate_project(&self.project_path))
   }
 


### PR DESCRIPTION
This enables users to specify whether Vibranium should restore the project's
vibranium.toml to its "factory" defaults.

```
$ vibranium reset --restore-config
```

By default, reset leaves `vibranium.toml` as is and in fact, reads it to change
the behaviour of reset.

Closes #15