### PR TITLE
feat(vibranium::blockchain): add strategy algorithm to support differ…

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -159,7 +159,7 @@ fn run() -> Result<(), Error> {
         client_options,
       };
     
-      vibranium.start_node(config)?;
+      vibranium.start_node(config).map_err(error::CliError::BlockchainError)?;
     },
 
     ("init", Some(cmd)) => {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -2,6 +2,7 @@ extern crate log;
 
 use std::process::{Command, Child};
 use crate::config;
+use support::SupportedBlockchainClients;
 
 pub mod error;
 pub mod support;
@@ -27,20 +28,38 @@ impl<'a> Node<'a> {
 
     let client = config.client.unwrap_or_else(|| {
       match &project_config.blockchain {
-        Some(config) => config.cmd.clone().unwrap_or_else(|| support::SupportedBlockchainClients::Parity.to_string()),
-        None => support::SupportedBlockchainClients::Parity.to_string(),
+        Some(config) => config.cmd.clone().unwrap_or_else(|| SupportedBlockchainClients::Parity.to_string()),
+        None => SupportedBlockchainClients::Parity.to_string(),
       }
     });
 
     let client_options: Vec<String> = match &config.client_options {
-      Some(options) => options.to_vec(),
+      Some(options) => {
+        match client.parse() {
+          Ok(SupportedBlockchainClients::Parity) => merge_defaults_with_options_for(SupportedBlockchainClients::Parity, options.to_vec()),
+          Ok(SupportedBlockchainClients::Geth) => merge_defaults_with_options_for(SupportedBlockchainClients::Geth, options.to_vec()),
+          Err(_err) => options.to_vec(),
+        }
+      }
       None => {
         match project_config.blockchain {
-          Some(config) => config.options.unwrap_or(default_options()),
-          None => default_options()
+          Some(config) => config.options.unwrap_or_else(|| {
+            match client.parse() {
+              Ok(SupportedBlockchainClients::Parity) => support::default_options_for(SupportedBlockchainClients::Parity),
+              Ok(SupportedBlockchainClients::Geth) => support::default_options_for(SupportedBlockchainClients::Geth),
+              Err(_err) => vec![],
+            }
+          }),
+          None => support::default_options_for(SupportedBlockchainClients::Parity)
         }
       }
     };
+
+    if client_options.is_empty() {
+      if let Err(err) = client.parse::<SupportedBlockchainClients>() {
+        Err(err)?
+      }
+    }
 
     info!("Starting node with command: {} {}", &client, client_options.join(" "));
 
@@ -51,6 +70,10 @@ impl<'a> Node<'a> {
   }
 }
 
-pub fn default_options() -> Vec<String> {
-  vec!["--config".to_string(), "dev".to_string()]
+fn merge_defaults_with_options_for(client: SupportedBlockchainClients, options: Vec<String>) -> Vec<String> {
+  let mut combined = support::default_options_for(client);
+  combined.append(&mut options.clone());
+  combined.sort();
+  combined.dedup();
+  combined
 }

--- a/src/blockchain/support.rs
+++ b/src/blockchain/support.rs
@@ -2,17 +2,20 @@ use super::error;
 use std::str::FromStr;
 use std::string::ToString;
 
-const DEFAULT_NODE_CLIENT: &str = "parity";
+const PARITY_CLIENT_CMD: &str = "parity";
+const GETH_CLIENT_CMD: &str = "geth";
 
 pub enum SupportedBlockchainClients {
   Parity,
+  Geth,
 }
 
 impl FromStr for SupportedBlockchainClients {
   type Err = error::NodeError;
   fn from_str(s: &str) -> Result<Self, Self::Err> {
     match s {
-      DEFAULT_NODE_CLIENT => Ok(SupportedBlockchainClients::Parity),
+      PARITY_CLIENT_CMD => Ok(SupportedBlockchainClients::Parity),
+      GETH_CLIENT_CMD => Ok(SupportedBlockchainClients::Geth),
       _ => Err(error::NodeError::UnsupportedClient),
     }
   }
@@ -21,7 +24,19 @@ impl FromStr for SupportedBlockchainClients {
 impl ToString for SupportedBlockchainClients {
   fn to_string(&self) -> String {
     match self {
-      SupportedBlockchainClients::Parity => DEFAULT_NODE_CLIENT.to_string(),
+      SupportedBlockchainClients::Parity => PARITY_CLIENT_CMD.to_string(),
+      SupportedBlockchainClients::Geth => GETH_CLIENT_CMD.to_string(),
     }
+  }
+}
+
+pub fn default_options_for(client: SupportedBlockchainClients) -> Vec<String> {
+  match client {
+    SupportedBlockchainClients::Parity => {
+      vec!["--config".to_string(), "dev".to_string()]
+    },
+    SupportedBlockchainClients::Geth => {
+      vec!["--dev".to_string(), "--rpc".to_string()]
+    },
   }
 }

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -113,7 +113,7 @@ pub fn default_project_config() -> config::ProjectConfig {
     }),
     blockchain: Some(config::ProjectCmdExecutionConfig {
       cmd: Some(blockchain::support::SupportedBlockchainClients::Parity.to_string()),
-      options: Some(blockchain::default_options())
+      options: Some(blockchain::support::default_options_for(blockchain::support::SupportedBlockchainClients::Parity))
     }),
   }
 }


### PR DESCRIPTION
…ent clients

This also adds built-in support for Geth client in dev mode:

```
$ vibranium node --client geth
```

Now works out of the box. As usual, it's still possible to use any other client
as long as all necessary options are applied:

```
$ vibranium node --client trinity -- option1 option2
```

Closes #21