### PR TITLE
feat(vibranium::cli): introduce --no-tracking flag for deploy command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,7 @@ use clap::{App, SubCommand, Arg};
 use vibranium::Vibranium;
 use vibranium::blockchain;
 use vibranium::deployment;
+use vibranium::deployment::DeployOptions;
 use vibranium::compiler::CompilerConfig;
 use vibranium::project_generator::ResetOptions;
 
@@ -155,6 +156,10 @@ fn run() -> Result<(), Error> {
                       .value_name("PATH")
                       .help("Specifies path to Vibranium project")
                       .takes_value(true))
+                    .arg(Arg::with_name("no-tracking")
+                      .short("nt")
+                      .long("no-tracking")
+                      .help("Specifices whether deployment tracking should be disabled"))
                     .arg(Arg::with_name("verbose")
                       .short("v")
                       .long("verbose")
@@ -284,7 +289,16 @@ fn run() -> Result<(), Error> {
       println!("Deploying...");
       let path = pathbuf_from_or_current_dir(cmd.value_of("path"))?;
       let vibranium = Vibranium::new(path);
-      vibranium.deploy()
+
+      let deploy_options = DeployOptions {
+        tracking_enabled: if cmd.is_present("no-tracking") {
+          Some(false)
+        } else {
+          None
+        }
+      };
+
+      vibranium.deploy(deploy_options)
         .map_err(|err| {
           match err {
             deployment::error::DeploymentError::Connection(connector_error) => error::CliError::BlockchainConnectorError(connector_error),

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -940,4 +940,51 @@ mod deploy_cmd {
     tmp_dir.close()?;
     Ok(())
   }
+
+  #[test]
+  fn it_should_not_track_deployment_when_notracking_flag_is_set() -> Result<(), Box<std::error::Error>> {
+    let mut config = ProjectConfig::default();
+    let contract_name = "SimpleTestContract";
+
+    config.deployment = Some(ProjectDeploymentConfig {
+      gas_limit: None,
+      gas_price: None,
+      tx_confirmations: None,
+      tracking_enabled: None,
+      smart_contracts: vec![
+        SmartContractConfig {
+          name: contract_name.to_string(),
+          args: Some(vec![
+            SmartContractArg { value: "200".to_string(),kind: "uint".to_string() },
+          ]),
+          gas_limit: None,
+          gas_price: None,
+        },
+      ],
+    });
+
+    let (tmp_dir, project_path) = setup_vibranium_project(Some(config))?;
+    create_test_contract(&project_path, "simple_test_contract.sol")?;
+
+    let mut cmd = Command::main_binary()?;
+    cmd.arg("compile")
+        .arg("--path")
+        .arg(&project_path);
+
+    cmd.assert().success();
+
+    let mut cmd = Command::main_binary()?;
+    cmd.arg("deploy")
+        .arg("--no-tracking")
+        .arg("--path")
+        .arg(&project_path);
+
+    cmd.assert().success();
+
+    let tracking_file = project_path.join(".vibranium").join("tracking.toml");
+    assert_eq!(tracking_file.exists(), false);
+
+    tmp_dir.close()?;
+    Ok(())
+  }
 }

--- a/src/deployment/mod.rs
+++ b/src/deployment/mod.rs
@@ -23,6 +23,10 @@ const DEFAULT_GAS_PRICE: usize = 5;
 const DEFAULT_GAS_LIMIT: usize = 2_000_000;
 const DEFAULT_DEV_TX_CONFIRMATION_AMOUNT: usize = 0;
 
+pub struct DeployOptions {
+  pub tracking_enabled: Option<bool>,
+}
+
 pub struct Deployer<'a> {
   config: &'a Config,
   connector: &'a BlockchainConnector,
@@ -38,7 +42,7 @@ impl<'a> Deployer<'a> {
     }
   }
 
-  pub fn deploy(&self) -> Result<HashMap<String, (String, Address, bool)>, DeploymentError>  {
+  pub fn deploy(&self, options: DeployOptions) -> Result<HashMap<String, (String, Address, bool)>, DeploymentError>  {
 
     let project_config = self.config.read()?;
 
@@ -58,7 +62,8 @@ impl<'a> Deployer<'a> {
     let confirmations = deployment_config.tx_confirmations.unwrap_or(DEFAULT_DEV_TX_CONFIRMATION_AMOUNT);
     let mut deployed_contracts = HashMap::new();
 
-    let tracking_enabled = deployment_config.tracking_enabled.unwrap_or(true);
+    let tracking_enabled = options.tracking_enabled
+      .unwrap_or(deployment_config.tracking_enabled.unwrap_or(true));
 
     if tracking_enabled && !self.tracker.database_exists() {
       self.tracker.create_database()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,10 +115,10 @@ impl Vibranium {
       })
   }
 
-  pub fn deploy(&self) -> Result<HashMap<String, (String, Address, bool)>, deployment::error::DeploymentError> {
+  pub fn deploy(&self, options: deployment::DeployOptions) -> Result<HashMap<String, (String, Address, bool)>, deployment::error::DeploymentError> {
     let (_eloop, connector) = self.get_blockchain_connector().map_err(deployment::error::DeploymentError::Connection)?;
     let tracker = deployment::tracker::DeploymentTracker::new(&self.config);
     let deployer = deployment::Deployer::new(&self.config, &connector, &tracker);
-    deployer.deploy()
+    deployer.deploy(options)
   }
 }


### PR DESCRIPTION
Similar to using the `tracking_enabled` flag in the project's vibranium.toml,
this commit enables users to add a `--no-tracking` flag to the deploy command
to disable tracking.

```
$ vibranium deploy --no-tracking
```