### PR TITLE
fix(vibranium::blockchain): provide Parity with dev account

### DIFF
--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -170,13 +170,9 @@ mod reset_cmd {
     assert_eq!(vibranium_dir.exists(), true);
     assert_eq!(artifacts_dir.exists(), true);
 
-    File::create(vibranium_dir.join("file1"))?;
-    File::create(vibranium_dir.join("file2"))?;
     File::create(artifacts_dir.join("file1"))?;
     File::create(artifacts_dir.join("file2"))?;
 
-    // `vibranium_dir` now includes `datadir` by default
-    assert_eq!(fs::read_dir(&vibranium_dir).unwrap().count(), 3);
     assert_eq!(fs::read_dir(&artifacts_dir).unwrap().count(), 2);
 
     let mut cmd = Command::main_binary()?;
@@ -185,8 +181,6 @@ mod reset_cmd {
         .arg(&project_path);
     cmd.assert().success();
 
-    // `vibranium_dir` now includes `datadir` by default
-    assert_eq!(fs::read_dir(&vibranium_dir).unwrap().count(), 1);
     assert_eq!(fs::read_dir(&artifacts_dir).unwrap().count(), 0);
     
     tmp_dir.close()?;

--- a/src/blockchain/error.rs
+++ b/src/blockchain/error.rs
@@ -42,6 +42,12 @@ impl From<ConfigError> for NodeError {
   }
 }
 
+impl From<io::Error> for NodeError {
+  fn from(error: io::Error) -> Self {
+    NodeError::Other(error.to_string())
+  }
+}
+
 #[derive(Debug)]
 pub enum ConnectionError {
   UnsupportedProtocol,

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -68,6 +68,8 @@ impl<'a> Node<'a> {
       }
     }
 
+    support::init_node(&client, &client_options, &self.config.vibranium_dir_path)?;
+
     info!("Starting node with command: {} {}", &client, client_options.join(" "));
 
     Command::new(client)

--- a/src/blockchain/support.rs
+++ b/src/blockchain/support.rs
@@ -1,10 +1,16 @@
 use super::error;
+use std::fs;
+use std::io::Write;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::string::ToString;
 
 use crate::project_generator;
-use project_generator::{DEFAULT_DATADIR_NAME, DEFAULT_DATADIR_ENVIRONMENT};
+use project_generator::{
+  DEFAULT_DATADIR_NAME,
+  DEFAULT_ENVIRONMENT,
+  DEFAULT_DEV_PASSWORDS_DIR,
+};
 
 const PARITY_CLIENT_BINARY_UNIX: &str = "parity";
 const PARITY_CLIENT_BINARY_WINDOWS: &str = "parity.exe";
@@ -12,6 +18,8 @@ const GETH_CLIENT_BINARY_UNIX: &str = "geth";
 const GETH_CLIENT_BINARY_WINDOWS: &str = "geth.exe";
 const GANACHE_CLIENT_BINARY: &str = "ganache-cli";
 
+const PARITY_DEFAULT_DEV_ACCOUNT: &str = "0x00a329c0648769a73afac7f9381e08fb43dbea72";
+const PARITY_PASSWORDS_FILE: &str = "parity_dev";
 
 pub enum SupportedBlockchainClients {
   Parity,
@@ -63,6 +71,32 @@ impl ToString for SupportedBlockchainClients {
   }
 }
 
+pub fn init_node(client: &str, options: &Vec<String>, vibranium_dir_path: &PathBuf) -> Result<(), std::io::Error> {
+  match client.parse() {
+    Ok(SupportedBlockchainClients::Parity) => {
+
+      let password_option = "--password".to_string();
+
+      if options.contains(&password_option) {
+        let i = options.iter().position(|v| v == &password_option).unwrap() + 1;
+        let default_password_dir = vibranium_dir_path.join(DEFAULT_DEV_PASSWORDS_DIR);
+        let default_password_file = default_password_dir.join(PARITY_PASSWORDS_FILE);
+
+        if options[i].ends_with(&default_password_file.to_str().unwrap()) && !default_password_file.exists() {
+          fs::create_dir_all(&default_password_dir)?;
+          let mut f = fs::File::create(&default_password_file)?;
+          f.write_all("\ndev_password".to_string().as_bytes())?
+        }
+      }
+
+      Ok(())
+    },
+    Ok(SupportedBlockchainClients::Geth) => Ok(()),
+    Ok(SupportedBlockchainClients::Ganache) => Ok(()),
+    Err(_) => Ok(()),
+  }
+}
+
 pub fn default_options_from(client: SupportedBlockchainClients, vibranium_dir_path: &PathBuf) -> Vec<String> {
   match client {
     SupportedBlockchainClients::Parity => {
@@ -74,7 +108,15 @@ pub fn default_options_from(client: SupportedBlockchainClients, vibranium_dir_pa
         "--base-path".to_string(),
         vibranium_dir_path
           .join(DEFAULT_DATADIR_NAME)
-          .join(DEFAULT_DATADIR_ENVIRONMENT)
+          .join(DEFAULT_ENVIRONMENT)
+          .to_string_lossy()
+          .to_string(),
+        "--unlock".to_string(),
+        PARITY_DEFAULT_DEV_ACCOUNT.to_string(),
+        "--password".to_string(),
+        vibranium_dir_path
+          .join(DEFAULT_DEV_PASSWORDS_DIR)
+          .join(PARITY_PASSWORDS_FILE)
           .to_string_lossy()
           .to_string(),
       ]
@@ -89,7 +131,7 @@ pub fn default_options_from(client: SupportedBlockchainClients, vibranium_dir_pa
         "--datadir".to_string(),
         vibranium_dir_path
           .join(DEFAULT_DATADIR_NAME)
-          .join(DEFAULT_DATADIR_ENVIRONMENT)
+          .join(DEFAULT_ENVIRONMENT)
           .to_string_lossy()
           .to_string(),
       ]
@@ -100,7 +142,7 @@ pub fn default_options_from(client: SupportedBlockchainClients, vibranium_dir_pa
         "--db".to_string(),
         vibranium_dir_path
           .join(DEFAULT_DATADIR_NAME)
-          .join(DEFAULT_DATADIR_ENVIRONMENT)
+          .join(DEFAULT_ENVIRONMENT)
           .to_string_lossy()
           .to_string(),
       ]

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -11,7 +11,8 @@ pub mod error;
 
 pub const VIBRANIUM_PROJECT_DIRECTORY: &str = ".vibranium";
 pub const DEFAULT_DATADIR_NAME: &str = "datadir";
-pub const DEFAULT_DATADIR_ENVIRONMENT: &str = "development";
+pub const DEFAULT_DEV_PASSWORDS_DIR: &str = "passwords";
+pub const DEFAULT_ENVIRONMENT: &str = "development";
 
 pub struct ProjectGenerator<'a> {
   config: &'a config::Config,
@@ -35,7 +36,8 @@ impl<'a> ProjectGenerator<'a> {
 
     let mut directories_to_create: Vec<PathBuf> = vec![
       project_path.join(VIBRANIUM_PROJECT_DIRECTORY),
-      project_path.join(VIBRANIUM_PROJECT_DIRECTORY).join(DEFAULT_DATADIR_NAME).join(DEFAULT_DATADIR_ENVIRONMENT),
+      project_path.join(VIBRANIUM_PROJECT_DIRECTORY).join(DEFAULT_DATADIR_NAME).join(DEFAULT_ENVIRONMENT),
+      project_path.join(VIBRANIUM_PROJECT_DIRECTORY).join(DEFAULT_DEV_PASSWORDS_DIR),
       project_path.join(config::DEFAULT_CONTRACTS_DIRECTORY),
     ];
 


### PR DESCRIPTION
This is needed to have parity process transactions. Parity requires the
options `--account` and `--password` which it will use to sign transactions
in dev mode.

`--password` is actually the path to a file that contains a list of passwords.
By default, vibranium will create a file `[project]/.vibranium/passwords/parity_dev`
with the password `dev_account` and the derivative address. That path is then used
unless `--password` is provided.

When users provide a custom path for `--password` they have to provide `--account`
as well.