### PR TITLE
feat(vibranium::cli): implement list command

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -11,6 +11,12 @@ use vibranium::blockchain::error::ConnectionError;
 use vibranium::deployment::error::DeploymentError;
 
 
+const ERROR_MESSAGE_CONNECTION_REFUSED: &str = "Unable to connect to blockchain. If you're trying to connect to a local blockchain node,
+make sure it's started first using the following command in a separate process:
+
+  $ vibranium node [--path ...]
+";
+
 #[derive(Debug)]
 pub enum CliError {
   CompilationError(CompilerError),
@@ -93,11 +99,7 @@ Make sure a blockchain connector configuration is provided in the project's vibr
             // to transform them to meaningful error messages.
             let error_message = error.to_string();
             if error_message.contains("Connection refused") {
-              write!(f, "Unable to connect to blockchain. If you're trying to connect to a local blockchain node,
-make sure it's started first using the following command in a separate process:
-
-  $ vibranium node [--path ...]
-")
+              write!(f, "{}", ERROR_MESSAGE_CONNECTION_REFUSED)
             } else if error_message.contains("invalid response") || error_message.contains("405 Method Not Allowed") {
               write!(f, "Unexpected blockchain client response. This is because of either a bad reponse from the blockchain client,
 or a wrong configuration of the blockchain connector (e.g. wrong port)")
@@ -124,7 +126,14 @@ Make sure a deployment configuration is provided in the project's vibranium.toml
           _ => write!(f, "{}", error)
         }
       },
-      CliError::Other(message) => write!(f, "{}", message),
+      CliError::Other(message) => {
+
+        if message.contains("Connection refused") {
+          write!(f, "{}", ERROR_MESSAGE_CONNECTION_REFUSED)
+        } else {
+          write!(f, "{}", message)
+        }
+      },
     }
   }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -164,7 +164,17 @@ fn run() -> Result<(), Error> {
                       .short("v")
                       .long("verbose")
                       .help("Generates verbose output"))
+                  )
+                  .subcommand(SubCommand::with_name("list")
+                    .about("List deployed application data")
+                    .arg(Arg::with_name("path")
+                      .short("p")
+                      .long("path")
+                      .value_name("PATH")
+                      .help("Specifies path to Vibranium project")
+                      .takes_value(true))
                   );
+                    
 
   let matches = app.clone().get_matches();
 
@@ -322,6 +332,22 @@ fn run() -> Result<(), Error> {
           }
           Ok(())
         })?
+    },
+
+    ("list", Some(cmd)) => {
+      let path = pathbuf_from_or_current_dir(cmd.value_of("path"))?;
+      let vibranium = Vibranium::new(path);
+      let tracking_data = vibranium.get_tracking_data().map_err(|err| error::CliError::Other(err.to_string()))?;
+
+      match tracking_data {
+        None => println!("No Smart Contract data for currently connected chain has been tracked."),
+        Some(data) => {
+          println!("Deployed Smart Contracts:");
+          for (_hash, smart_contract) in data {
+            println!("  {:?}: {}", smart_contract.address, smart_contract.name);
+          }
+        }
+      }
     },
 
     _ => {

--- a/src/blockchain/connector/mod.rs
+++ b/src/blockchain/connector/mod.rs
@@ -80,6 +80,10 @@ impl BlockchainConnector {
     self.adapter.get_block(block).wait().map_err(ConnectionError::Transport)
   }
 
+  pub fn get_first_block(&self) -> Result<Option<Block<H256>>, ConnectionError> {
+    self.get_block(BlockId::Number(BlockNumber::Number(0)))
+  }
+
   pub fn deploy(&self, bytes: &[u8]) -> Result<web3::contract::deploy::Builder<web3_adapter::Transports>, ethabi::Error> {
     self.adapter.deploy(bytes)
   }

--- a/src/blockchain/error.rs
+++ b/src/blockchain/error.rs
@@ -3,6 +3,7 @@ use std::io;
 use std::fmt;
 use std::error::Error;
 use crate::config::error::ConfigError;
+use crate::deployment::error::DeploymentTrackingError;
 
 #[derive(Debug)]
 pub enum NodeError {
@@ -75,5 +76,11 @@ impl fmt::Display for ConnectionError {
       ConnectionError::Transport(error) => write!(f, "{}", error),
       ConnectionError::Other(message) => write!(f, "{}", message),
     }
+  }
+}
+
+impl From<DeploymentTrackingError> for ConnectionError {
+  fn from(error: DeploymentTrackingError) -> Self {
+    ConnectionError::Other(error.to_string())
   }
 }

--- a/src/deployment/error.rs
+++ b/src/deployment/error.rs
@@ -93,6 +93,7 @@ impl From<ethabi::Error> for DeploymentError {
 #[derive(Debug)]
 pub enum DeploymentTrackingError {
   Other(String),
+  DatabaseNotFound,
   Deserialization(toml::de::Error),
   Serialization(toml::ser::Error),
   Insertion(toml_query::error::Error),
@@ -105,6 +106,7 @@ impl Error for DeploymentTrackingError {
   fn cause(&self) -> Option<&Error> {
     match self {
       DeploymentTrackingError::Other(_) => None,
+      DeploymentTrackingError::DatabaseNotFound => None,
       DeploymentTrackingError::Deserialization(error) => Some(error),
       DeploymentTrackingError::Serialization(error) => Some(error),
       DeploymentTrackingError::Insertion(_error) => None,
@@ -119,6 +121,7 @@ impl fmt::Display for DeploymentTrackingError {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     match self {
       DeploymentTrackingError::Other(message) => write!(f, "{}", message),
+      DeploymentTrackingError::DatabaseNotFound => write!(f, "Couldn't find tracking database"),
       DeploymentTrackingError::Deserialization(error) => write!(f, "Couldn't deserialize tracking data: {}", error),
       DeploymentTrackingError::Serialization(error) => write!(f, "Couldn't serialize tracking data: {}", error),
       DeploymentTrackingError::Insertion(error) => write!(f, "Couldn't insert tracking data before writing to disc: {}", error),
@@ -149,6 +152,12 @@ impl From<toml::ser::Error> for DeploymentTrackingError {
 
 impl From<toml_query::error::Error> for DeploymentTrackingError {
   fn from(error: toml_query::error::Error) -> Self {
+    DeploymentTrackingError::Other(error.to_string())
+  }
+}
+
+impl From<blockchain::error::ConnectionError> for DeploymentTrackingError {
+  fn from(error: blockchain::error::ConnectionError) -> Self {
     DeploymentTrackingError::Other(error.to_string())
   }
 }

--- a/src/deployment/mod.rs
+++ b/src/deployment/mod.rs
@@ -13,7 +13,7 @@ use blockchain::connector::{BlockchainConnector};
 use config::{Config, SmartContractArg};
 use web3::contract::Options;
 use web3::futures::Future;
-use web3::types::{U256, H256, Address, BlockId, BlockNumber};
+use web3::types::{U256, H256, Address};
 use error::DeploymentError;
 use tracker::DeploymentTracker;
 
@@ -99,7 +99,7 @@ impl<'a> Deployer<'a> {
 
           if tracking_enabled {
             let block_hash = self.get_first_block_hash().unwrap();
-            let tracked_contract = self.tracker.get_tracking_data(&block_hash, &smart_contract_config.name, &bytecode, &args)?;
+            let tracked_contract = self.tracker.get_smart_contract_tracking_data(&block_hash, &smart_contract_config.name, &bytecode, &args)?;
 
             if let Some(tracked_contract) = tracked_contract {
               info!("{} is already deployed at {}", &tracked_contract.name, &tracked_contract.address);
@@ -141,7 +141,7 @@ impl<'a> Deployer<'a> {
   }
 
   fn get_first_block_hash(&self) -> Result<H256, DeploymentError> {
-    let block = self.connector.get_block(BlockId::Number(BlockNumber::Number(0)))?.unwrap();
+    let block = self.connector.get_first_block()?.unwrap();
     Ok(block.hash.unwrap())
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,4 +121,12 @@ impl Vibranium {
     let deployer = deployment::Deployer::new(&self.config, &connector, &tracker);
     deployer.deploy(options)
   }
+
+  pub fn get_tracking_data(&self) -> Result<Option<deployment::tracker::SmartContractTrackingData>, deployment::error::DeploymentTrackingError> {
+    let (_eloop, connector) = self.get_blockchain_connector()?;
+    let tracker = deployment::tracker::DeploymentTracker::new(&self.config);
+    connector.get_first_block()
+      .map_err(|err| deployment::error::DeploymentTrackingError::Other(err.to_string()))
+      .and_then(|block| tracker.get_all_smart_contract_tracking_data(&block.unwrap().hash.unwrap()))
+  }
 }

--- a/src/project_generator/mod.rs
+++ b/src/project_generator/mod.rs
@@ -6,6 +6,7 @@ use std::fs;
 use std::io::Write;
 
 use crate::config;
+use crate::deployment::tracker::TRACKING_FILE;
 
 pub mod error;
 


### PR DESCRIPTION
This introduces a new `list` command that outputs tracked data specific to
the connected chain.

```
$ vibranium list
```

Notice that this requires a blockchain connection as Vibrnanium needs to
calculate a hash of the first block of the connected blockchain.

Closes #37