### PR TITLE
fix(vibranium::cli): don't exit with error due to warnings in compile command

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -282,6 +282,9 @@ fn run() -> Result<(), Error> {
         .compile(config)
         .map_err(error::CliError::CompilationError)
         .and_then(|output| {
+          if !output.stderr.is_empty() {
+            io::stderr().write_all(&output.stderr).unwrap();
+          }
           io::stdout().write_all(&output.stdout).unwrap();
           println!("Done.");
           Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ impl Vibranium {
       })
       .and_then(|output| output)
       .and_then(|output| {
-        if !output.stderr.is_empty() {
+        if !output.status.success() {
           Err(compiler::error::CompilerError::Other(String::from_utf8_lossy(&output.stderr).to_string()))
         } else {
           Ok(output)


### PR DESCRIPTION


Fixes #72