### PR TITLE
chore(ci): move back to using Solcjs for faster builds

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -39,29 +39,30 @@ jobs:
         inputs:
           versionSpec: "10.5.0"
         displayName: Install Node
-      - script: |
-          mkdir -p ../Downloads
-          cd ../Downloads
-          curl -L -o "solc" "https://github.com/ethereum/solidity/releases/download/v0.5.9/solc-static-linux"
-          chmod +x solc
-        displayName: Linux install Solc
-        condition: eq( variables['Agent.OS'], 'Linux' )
-      - script: |
-          brew update
-          brew upgrade
-          brew tap ethereum/ethereum
-          brew install solidity
-        displayName: Mac install Solc
-        condition: eq( variables['Agent.OS'], 'Darwin' )
-      - powershell: |
-          mkdir -p ../Downloads
-          $client = new-object System.Net.WebClient
-          $client.DownloadFile("https://github.com/ethereum/solidity/releases/download/v0.5.9/solidity-windows.zip", "..\Downloads\solidity-windows.zip")
-          Expand-Archive –Path “..\Downloads\solidity-windows.zip” –Destination “..\Downloads\solidity-windows”
-        displayName: Windows install Solc 
-        condition: eq( variables['Agent.OS'], 'Windows_NT' )
-      - script: |
-          npm install -g ganache-cli
+      - script: npm install -g solc
+        displayName: Install Solcjs
+      #- script: |
+          #mkdir -p ../Downloads
+          #cd ../Downloads
+          #curl -L -o "solc" "https://github.com/ethereum/solidity/releases/download/v0.5.9/solc-static-linux"
+          #chmod +x solc
+        #displayName: Linux install Solc
+        #condition: eq( variables['Agent.OS'], 'Linux' )
+      #- script: |
+          #brew update
+          #brew upgrade
+          #brew tap ethereum/ethereum
+          #brew install solidity
+        #displayName: Mac install Solc
+        #condition: eq( variables['Agent.OS'], 'Darwin' )
+      #- powershell: |
+          #mkdir -p ../Downloads
+          #$client = new-object System.Net.WebClient
+          #$client.DownloadFile("https://github.com/ethereum/solidity/releases/download/v0.5.9/solidity-windows.zip", "..\Downloads\solidity-windows.zip")
+          #Expand-Archive –Path “..\Downloads\solidity-windows.zip” –Destination “..\Downloads\solidity-windows”
+        #displayName: Windows install Solc 
+        #condition: eq( variables['Agent.OS'], 'Windows_NT' )
+      - script: npm install -g ganache-cli
         displayName: Install Ganache CLI
       #- script: bash <(curl https://get.parity.io -L)
         #condition: ne( variables['Agent.OS'], 'Windows_NT' )
@@ -102,7 +103,7 @@ jobs:
         displayName: Windows start Ganache
         condition: eq( variables['Agent.OS'], 'Windows_NT' )
       - bash: |
-          export PATH="$(cd ../Downloads && pwd):${PATH}"
-          export PATH="$(cd ../Downloads/solidity-windows && pwd):${PATH}"
+          #export PATH="$(cd ../Downloads && pwd):${PATH}"
+          #export PATH="$(cd ../Downloads/solidity-windows && pwd):${PATH}"
           cd cli && cargo test --all
         displayName: Cargo test vibranium-cli

--- a/cli/tests/cli.rs
+++ b/cli/tests/cli.rs
@@ -279,6 +279,8 @@ mod reset_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -481,6 +483,8 @@ mod compile_cmd {
     let mut cmd = Command::main_binary()?;
 
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -653,6 +657,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -702,6 +708,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -783,6 +791,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -829,6 +839,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -883,6 +895,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -927,6 +941,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -982,6 +998,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -1028,6 +1046,8 @@ mod deploy_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 
@@ -1110,6 +1130,8 @@ mod list_cmd {
 
     let mut cmd = Command::main_binary()?;
     cmd.arg("compile")
+        .arg("--compiler")
+        .arg("solcjs")
         .arg("--path")
         .arg(&project_path);
 


### PR DESCRIPTION
Now that https://github.com/ethereum/solc-js/pull/367 has landed in solcjs and published,
we can roll back to using it again, making the CI setup significantly more
trivial and faster.

Closes #63