### PR TITLE
feat(vibranium::accounts_manager): introduce AccountsManager

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -299,9 +299,7 @@ fn run() -> Result<(), Error> {
     ("accounts", Some(cmd)) => {
       let path = pathbuf_from_or_current_dir(cmd.value_of("path"))?;
       let vibranium = Vibranium::new(path)?;
-
-      let (_eloop, connector) = vibranium.get_blockchain_connector().map_err(error::CliError::BlockchainConnectorError)?;
-      let accounts = connector.accounts().map_err(error::CliError::BlockchainConnectorError)?;
+      let accounts = vibranium.node_accounts()?;
 
       for (i, address) in accounts.iter().enumerate() {
         println!("({}) {:?}", i, address);

--- a/src/accounts_manager/error.rs
+++ b/src/accounts_manager/error.rs
@@ -1,0 +1,31 @@
+use crate::blockchain::error::ConnectionError;
+use std::convert::From;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+pub enum AccountsError {
+  Other(String),
+}
+
+impl Error for AccountsError {
+  fn cause(&self) -> Option<&Error> {
+    match self {
+      AccountsError::Other(_message) => None,
+    }
+  }
+}
+
+impl fmt::Display for AccountsError {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      AccountsError::Other(message) => write!(f, "{}", message),
+    }
+  }
+}
+
+impl From<ConnectionError> for AccountsError {
+  fn from(error: ConnectionError) -> Self {
+    AccountsError::Other(error.to_string())
+  }
+}

--- a/src/accounts_manager/mod.rs
+++ b/src/accounts_manager/mod.rs
@@ -1,0 +1,20 @@
+pub mod error;
+
+use crate::blockchain::connector::BlockchainConnector;
+use web3::types::Address;
+
+pub struct AccountsManager<'a> {
+  connector: &'a BlockchainConnector,
+}
+
+impl<'a> AccountsManager<'a> {
+  pub fn new(connector: &'a BlockchainConnector) -> AccountsManager<'a> {
+    AccountsManager {
+      connector,
+    }
+  }
+
+  pub fn get_node_accounts(&self) -> Result<Vec<Address>, error::AccountsError> {
+    self.connector.accounts().map_err(|err| error::AccountsError::Other(err.to_string()))
+  }
+}

--- a/src/deployment/mod.rs
+++ b/src/deployment/mod.rs
@@ -1,7 +1,7 @@
 pub mod error;
 pub mod tracker;
 
-use blockchain::connector::{BlockchainConnector};
+use blockchain::connector::BlockchainConnector;
 use config::{Config, SmartContractConfig, SmartContractArg};
 use crate::blockchain;
 use crate::config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate sha3;
 extern crate toml;
 extern crate toml_query;
 
+pub mod accounts_manager;
 pub mod blockchain;
 pub mod project_generator;
 pub mod compiler;
@@ -23,6 +24,7 @@ use std::path::PathBuf;
 use blockchain::connector as connector;
 use project_generator::error::ProjectGenerationError;
 use utils::adjust_canonicalization;
+use web3::types::Address;
 
 #[derive(Debug)]
 pub struct Vibranium {
@@ -115,6 +117,12 @@ impl Vibranium {
         let blockchain_connector = connector::BlockchainConnector::new(adapter);
         Ok((eloop, blockchain_connector))
       })
+  }
+
+  pub fn node_accounts(&self) -> Result<Vec<Address>, accounts_manager::error::AccountsError> {
+    let (_eloop, connector) = self.get_blockchain_connector()?;
+    let accounts_manager = accounts_manager::AccountsManager::new(&connector);
+    accounts_manager.get_node_accounts()
   }
 
   pub fn deploy(&self, options: deployment::DeployOptions) -> Result<deployment::DeployedContracts, deployment::error::DeploymentError> {


### PR DESCRIPTION
This also introduces a new `node_accounts()` API that is used in the CLI
`accounts` command. The next step will be to make the AccountsManager aware
of wallet accounts provided by the user.